### PR TITLE
Add profile page with user update route

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,7 @@ import GameLobby from "@/pages/GameLobby";
 import GameRoom from "@/pages/GameRoom";
 import Collection from "@/pages/Collection";
 import DeckBuilder from "@/pages/DeckBuilder";
+import Profile from "@/pages/Profile";
 import NotFound from "@/pages/not-found";
 import Navigation from "@/components/layout/Navigation";
 import StarBackground from "@/components/layout/StarBackground";
@@ -38,6 +39,7 @@ function Router() {
             <Route path="/game/:gameId" component={GameRoom} />
             <Route path="/collection" component={Collection} />
             <Route path="/deck-builder" component={DeckBuilder} />
+            <Route path="/profile" component={Profile} />
           </>
         )}
         <Route component={NotFound} />

--- a/client/src/pages/Profile.tsx
+++ b/client/src/pages/Profile.tsx
@@ -1,0 +1,50 @@
+import { useState, useEffect } from "react";
+import { useAuth } from "@/hooks/useAuth";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useToast } from "@/hooks/use-toast";
+
+export default function Profile() {
+  const { user, isAuthenticated } = useAuth();
+  const { toast } = useToast();
+  const [username, setUsername] = useState("");
+
+  useEffect(() => {
+    if (user) {
+      setUsername(user.username || "");
+    }
+  }, [user]);
+
+  if (!isAuthenticated) {
+    window.location.href = "/api/login";
+    return null;
+  }
+
+  const saveProfile = async () => {
+    try {
+      const res = await fetch("/api/user/profile", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username }),
+        credentials: "include",
+      });
+      if (!res.ok) throw new Error("failed");
+      toast({ title: "Profile updated" });
+    } catch {
+      toast({ title: "Failed to update", variant: "destructive" });
+    }
+  };
+
+  return (
+    <div className="container mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-4">Your Profile</h1>
+      <div className="max-w-sm space-y-4">
+        <div>
+          <label className="block mb-1 text-sm">Username</label>
+          <Input value={username} onChange={(e) => setUsername(e.target.value)} />
+        </div>
+        <Button onClick={saveProfile}>Save</Button>
+      </div>
+    </div>
+  );
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -24,6 +24,18 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  app.put('/api/user/profile', isAuthenticated, async (req: any, res) => {
+    try {
+      const userId = req.user.claims.sub;
+      const updates = req.body;
+      const user = await storage.updateUserProfile(userId, updates);
+      res.json(user);
+    } catch (error) {
+      console.error('Error updating profile:', error);
+      res.status(500).json({ message: 'Failed to update profile' });
+    }
+  });
+
   // Card routes
   app.get('/api/cards', async (req, res) => {
     try {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -37,6 +37,7 @@ export interface IStorage {
   upsertUser(user: UpsertUser): Promise<User>;
   getUserByUsername(username: string): Promise<User | undefined>;
   updateUserStats(userId: string, stats: { gamesPlayed?: number; gamesWon?: number; experience?: number; level?: number; credits?: number }): Promise<void>;
+  updateUserProfile(userId: string, updates: Partial<Omit<UpsertUser, "id">>): Promise<User>;
 
   // Card operations
   getAllCards(): Promise<Card[]>;
@@ -110,6 +111,15 @@ export class DatabaseStorage implements IStorage {
     await db.update(users)
       .set({ ...stats, updatedAt: new Date() })
       .where(eq(users.id, userId));
+  }
+
+  async updateUserProfile(userId: string, updates: Partial<Omit<UpsertUser, "id">>): Promise<User> {
+    const [updated] = await db
+      .update(users)
+      .set({ ...updates, updatedAt: new Date() })
+      .where(eq(users.id, userId))
+      .returning();
+    return updated;
   }
 
   // Card operations


### PR DESCRIPTION
## Summary
- implement `updateUserProfile` storage method
- add API route `/api/user/profile` to update profile data
- create new `Profile` page with simple form
- include profile page in application router

## Testing
- `npm run check` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68409308cb9c83279fe18e99cd905e44